### PR TITLE
Update the URL of Japanese help.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -6,5 +6,5 @@ Redmine::Plugin.register :redmine_japanese_help do
   description 'replace help link to Redmine.JP'
   version '0.0.1'
   delete_menu_item :top_menu, :help
-  menu :top_menu, :help, 'http://redmine.jp/guide/', :last => true
+  menu :top_menu, :help, 'http://guide.redmine.jp/', :last => true
 end


### PR DESCRIPTION
Redmine Guide (Japanese) has moved from http://redmine.jp/guide/ to http://guide.redmine.jp/.